### PR TITLE
🔧 make package.json point to the new recoverage repo

### DIFF
--- a/packages/recoverage/package.json
+++ b/packages/recoverage/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "recoverage",
 	"version": "0.1.6",
-	"license": "MIT",
+	"license": "BSD-3-Clause",
 	"author": {
 		"name": "Jeremy Banka",
 		"email": "hello@jeremybanka.com"
@@ -11,7 +11,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/jeremybanka/wayforge.git",
+		"url": "git+https://github.com/jeremybanka/recoverage.git",
 		"directory": "packages/recoverage"
 	},
 	"type": "module",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated license to BSD-3-Clause

- Changed repository URL to recoverage repo


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Modify package.json license and repository link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/recoverage/package.json

<li>Changed license from MIT to BSD-3-Clause<br> <li> Updated repository URL from wayforge to recoverage


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/recoverage/pull/8/files#diff-4f4525e96a8a9853417e0718980575a25cdd72166ba914129eb2fa675b95f286">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>