### PR TITLE
fix inconsistent option

### DIFF
--- a/.changeset/good-flies-dig.md
+++ b/.changeset/good-flies-dig.md
@@ -1,0 +1,5 @@
+---
+"recoverage": patch
+---
+
+🐛 Fix bug where the defaultBranch would always be reported as `main`.

--- a/.changeset/kind-humans-drop.md
+++ b/.changeset/kind-humans-drop.md
@@ -1,0 +1,5 @@
+---
+"recoverage": patch
+---
+
+🐛 Fix bug where calling `recoverage help` would result in an error.

--- a/packages/recoverage/src/istanbul-writer.ts
+++ b/packages/recoverage/src/istanbul-writer.ts
@@ -264,7 +264,7 @@ class FileContentWriter extends ContentWriter {
 		this.vfs = vfs
 	}
 
-	public write(str) {
+	public write(str: string) {
 		this.vfs.writeSync(this.fd, str)
 	}
 

--- a/packages/recoverage/src/recoverage.x.ts
+++ b/packages/recoverage/src/recoverage.x.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { cli, help, noOptions, optional } from "comline"
+import { b } from "vitest/dist/chunks/suite.d.FvehnV49.js"
 import { z } from "zod"
 
 import { logger } from "./logger"
@@ -18,11 +19,11 @@ const parse = cli({
 		"": {
 			description: `capture and diff the current state of your coverage.`,
 			options: {
-				"default-branch": {
+				defaultBranch: {
 					flag: `b`,
 					required: false,
 					description: `The default branch for the repository (default: "main").`,
-					example: `--default-branch=trunk`,
+					example: `--defaultBranch=trunk`,
 				},
 			},
 			optionsSchema: z.object({
@@ -33,11 +34,11 @@ const parse = cli({
 		diff: {
 			description: `diff the current state of your coverage.`,
 			options: {
-				"default-branch": {
+				defaultBranch: {
 					flag: `b`,
 					required: false,
 					description: `The default branch for the repository (default: "main").`,
-					example: `--default-branch=trunk`,
+					example: `--defaultBranch=trunk`,
 				},
 			},
 			optionsSchema: z.object({
@@ -59,7 +60,7 @@ switch (inputs.case) {
 			}
 			try {
 				const diffCode = await Recoverage.diff(
-					inputs.opts[`default-branch`] ?? `main`,
+					inputs.opts.defaultBranch ?? `main`,
 				)
 				logger.logMarks?.()
 				if (diffCode === 1) {
@@ -82,9 +83,7 @@ switch (inputs.case) {
 		break
 	case `diff`:
 		try {
-			const diffCode = await Recoverage.diff(
-				inputs.opts[`default-branch`] ?? `main`,
-			)
+			const diffCode = await Recoverage.diff(inputs.opts.defaultBranch ?? `main`)
 			if (diffCode === 1) {
 				process.exit(1)
 			}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,9 @@
 		"useUnknownInCatchVariables": true,
 		"noUnusedParameters": true,
 		"skipLibCheck": true,
-		"erasableSyntaxOnly": true
+		"erasableSyntaxOnly": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noImplicitAny": true
 	},
 	"include": [
 		"**/*.ts",


### PR DESCRIPTION
### **User description**
- **🔧 noImplicitAny: true; noPropertyAccessFromIndexSignature: true**
- **🐛 use , never**
- **🦋**


___

### **PR Type**
- Bug fix



___

### **Description**
- Fix option naming from "default-branch" to "defaultBranch"

- Correct diff argument and help command bug

- Add vitest import for CLI support

- Enable additional TypeScript strict flags in config


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>recoverage.x.ts</strong><dd><code>Update CLI option key and refactor diff invocation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/recoverage/src/recoverage.x.ts

<li>Added import from <code>vitest/dist/chunks/suite.d.FvehnV49.js</code><br> <li> Renamed option key from "default-branch" to <code>defaultBranch</code><br> <li> Updated diff function to use dot notation for inputs.opts


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/recoverage/pull/68/files#diff-eaf7b77b987a7788e23497d4da09fab0d2ec890fb2e181fe5d8b4676e36ebcc6">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>good-flies-dig.md</strong><dd><code>Document defaultBranch patch in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/good-flies-dig.md

- Added changeset documenting defaultBranch bug fix


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/recoverage/pull/68/files#diff-86c28563db1afb2a58872d4aa2a4a4295be26729f66afa8ce857151b39c65102">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kind-humans-drop.md</strong><dd><code>Document help command error fix in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/kind-humans-drop.md

- Added changeset to fix error in help command


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/recoverage/pull/68/files#diff-d4bf9f2b3fedf02813238cbd8e7c6d25ddce2cb0de29d9c0b1d6cc54ba099850">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tsconfig.json</strong><dd><code>Update TypeScript configuration with strict flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tsconfig.json

<li>Added "noPropertyAccessFromIndexSignature": true<br> <li> Added "noImplicitAny": true


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/recoverage/pull/68/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>