### PR TITLE
timestamp brand

### DIFF
--- a/recoverage.cloud/src/schema.ts
+++ b/recoverage.cloud/src/schema.ts
@@ -6,10 +6,17 @@ import type { JsonSummary } from "recoverage"
 import type { Json } from "./json"
 import type { Role } from "./roles-permissions"
 
+type ISO8601 = string & { __brand__: `ISO8601` }
+
+const SQL_NOW = sql`(current_timestamp)`
+function timestamp() {
+	return text().$type<ISO8601>()
+}
+
 export const users = sqliteTable(`users`, {
 	id: integer().primaryKey(),
 	role: text().$type<Role>().default(`free`).notNull(),
-	createdAt: text().notNull().default(sql`(current_timestamp)`),
+	createdAt: timestamp().default(SQL_NOW).notNull(),
 })
 
 export const projects = sqliteTable(`projects`, {
@@ -18,7 +25,7 @@ export const projects = sqliteTable(`projects`, {
 		.references(() => users.id, { onDelete: `cascade` })
 		.notNull(),
 	name: text().notNull(),
-	createdAt: text().notNull().default(sql`(current_timestamp)`),
+	createdAt: timestamp().default(SQL_NOW).notNull(),
 })
 export const projectsRelations = relations(projects, ({ many, one }) => ({
 	tokens: many(tokens),
@@ -37,9 +44,8 @@ export const tokens = sqliteTable(`tokens`, {
 	projectId: text()
 		.references(() => projects.id, { onDelete: `cascade` })
 		.notNull(),
-	createdAt: text().notNull().default(sql`(current_timestamp)`),
+	createdAt: timestamp().default(SQL_NOW).notNull(),
 })
-
 export const tokensRelations = relations(tokens, ({ one }) => ({
 	project: one(projects, {
 		fields: [tokens.projectId],
@@ -56,7 +62,7 @@ export const reports = sqliteTable(
 			.notNull(),
 		data: text().notNull().$type<Json.stringified<CoverageMap>>(),
 		jsonSummary: text().$type<Json.stringified<JsonSummary>>(),
-		createdAt: text().notNull().default(sql`(current_timestamp)`),
+		createdAt: timestamp().default(SQL_NOW).notNull(),
 	},
 	(table) => [
 		primaryKey({
@@ -65,7 +71,6 @@ export const reports = sqliteTable(
 		}),
 	],
 )
-
 export const reportsRelations = relations(reports, ({ one }) => ({
 	projects: one(projects, {
 		fields: [reports.projectId],


### PR DESCRIPTION
### **User description**
- **🏷️  add brand for timestamp**
- **🗃️  add a migration, i guess**


___

### **PR Type**
Enhancement


___

### **Description**
- Branded `ISO8601` timestamp type with helper

- Replace `createdAt` columns to typed timestamps

- Add migration SQL script for timestamp updates

- Update Drizzle snapshot and journal metadata


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.ts</strong><dd><code>Use branded timestamp type for createdAt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

recoverage.cloud/src/schema.ts

<li>Added <code>ISO8601</code> branded string type<br> <li> Introduced <code>timestamp()</code> helper and <code>SQL_NOW</code><br> <li> Updated <code>createdAt</code> to use typed timestamp


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/recoverage/pull/236/files#diff-c768c10dcef2c725bb0a455f829663b499f3942304a2e1fdf011ab45f2c6e876">+11/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0004_elite_sabretooth.sql</strong><dd><code>Migration script for timestamp columns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

recoverage.cloud/drizzle/0004_elite_sabretooth.sql

<li>New migration script for timestamp changes<br> <li> Recreate tables to apply <code>current_timestamp</code> default<br> <li> Insert and rename tables preserving data


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/recoverage/pull/236/files#diff-aac20f94161d81af22de1f6f334effb7384e19a087278765a8523fc82bf80006">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>0004_snapshot.json</strong><dd><code>Updated schema snapshot for timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

recoverage.cloud/drizzle/meta/0004_snapshot.json

<li>Updated schema snapshot with timestamp defaults<br> <li> Reflect <code>createdAt</code> default <code>current_timestamp</code>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/recoverage/pull/236/files#diff-1314442c74fa98b29a4658e2e678b2e8158d16d3c3c9b713ab913c8b4a1fd85b">+239/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_journal.json</strong><dd><code>Append new migration journal entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

recoverage.cloud/drizzle/meta/_journal.json

- Added migration entry `0004_elite_sabretooth`


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/recoverage/pull/236/files#diff-93c35c022358b624092eb8bd008fd9d42633f1f9773084e80e4a30360e73d39e">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>