### PR TITLE
Upgrade Changesets to v3

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,13 @@
 {
-	"$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+	"$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
 	"changelog": "@changesets/cli/changelog",
 	"commit": false,
+	"format": false,
 	"fixed": [],
 	"linked": [],
 	"access": "restricted",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
+	"privatePackages": false,
 	"ignore": []
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
           node-version-file: .node_version
           registry-url: https://registry.npmjs.org
       - uses: ./.github/actions/setup
-      - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+      - uses: changesets/action@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: bun release
-          version: ./version.sh
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          publish-script: bun release
+          version-script: ./version.sh
+          github-token: ${{ steps.app-token.outputs.token }}
+          push-with-git-cli: true


### PR DESCRIPTION
## Summary

- upgrade `@changesets/cli` from 2.31.1 to 3.0.0 and refresh the complete Changesets dependency graph in `bun.lock`
- upgrade `changesets/action` from 1.9.0 to 2.0.0, which is the action line compatible with Changesets v3
- migrate the Changesets config schema and make formatter/private-workspace behavior explicit

## Migration audit

I reviewed the official [`@changesets/cli` 3.0.0 changelog](https://github.com/changesets/changesets/blob/main/packages/cli/CHANGELOG.md#300), the [`@changesets/config` 4.0.0 changelog](https://github.com/changesets/changesets/blob/main/packages/config/CHANGELOG.md#400), and the [`changesets/action` 2.0.0 changelog](https://github.com/changesets/action/blob/main/CHANGELOG.md#200).

- **Runtime floors:** Changesets v3 requires Node `^22.11 || ^24 || >=26`; this repository uses Node 26.2.0. The npm/pnpm/Yarn engine changes do not require a repo change. This Bun workspace continues to execute Changesets through Bun, while Changesets delegates publishing to the available npm CLI set up in the release workflow.
- **Action compatibility and inputs:** Action v2 embeds Changesets v3 and rejects CLI v2. The workflow now uses `publish-script` and `version-script`, passes the GitHub App token through the required `github-token` input, and sets `push-with-git-cli: true` to preserve the v1 push mode.
- **Publishing authentication:** Action v2 no longer manages `.npmrc` from `NPM_TOKEN`. The existing `actions/setup-node` `registry-url` configuration and `id-token: write` permission already provide the documented trusted-publishing setup.
- **Formatter config:** v3 replaces the old `prettier` option with `format`. `format: false` is intentional because `version.sh` immediately applies the repository's Biome formatter after `changeset version`.
- **Private packages:** v3 no longer versions private workspaces by default. `privatePackages: false` makes that intended behavior explicit for the unversioned cloud app and fixture workspace.
- **No-op versioning:** `changeset version` now exits 1 when there are no pending changesets. The action checks Changesets state before invoking the custom version script, so no workflow migration is needed.
- **Commands/config not used here:** there are no uses of the renamed `changeset tag` command, removed `--sinceMaster` flag, removed legacy snapshot config, old `prettier` option, or prerelease `pre.json` state.
- **Behavioral changes accepted:** peer-dependency updates now cause dependent patch bumps instead of major bumps, and private packages remain outside the release plan. The repository does not import Changesets APIs directly, so the new ESM-only packages and lower-level API removals require no source migration.

## Verification

- `bun changeset --version` → 3.0.0
- `bun changeset status --since=main`
- `bun fmt`
- `bun lint:deps`
- `bun lint`
- `bun run build`
- ordinary package unit tests: 4 passed across the package and cloud suites
- CI: Biome, dependency pinning, ESLint, types, build, Vitest, coverage, break check, preview deploy, and security checks pass

No Changeset is included because this changes release tooling only and does not alter the published package.
