### PR TITLE
Adopt dprint with Biome formatting

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
 	"$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
 	"changelog": "@changesets/cli/changelog",
 	"commit": false,
-	"format": false,
+	"format": "dprint",
 	"fixed": [],
 	"linked": [],
 	"access": "restricted",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,10 @@
 	// FILE FORMATTING ////////////////////////////////////////////////////////////
 	"editor.formatOnSave": true,
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
-	"[json][jsonc][typescript][typescriptreact][css]": {
-		"editor.defaultFormatter": "biomejs.biome"
+	"[javascript][javascriptreact][json][jsonc][typescript][typescriptreact][css]": {
+		"editor.defaultFormatter": "dprint.dprint"
 	},
+	"dprint.path": "node_modules/.bin/dprint",
 	"editor.codeActionsOnSave": { "source.fixAll.eslint": "explicit" },
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"coverage-gutters.coverageBaseDir": "**/coverage/",

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -3,7 +3,7 @@
 		"TypeScript": {
 			"formatter": {
 				"language_server": {
-					"name": "biome"
+					"name": "dprint"
 				}
 			},
 			"code_actions_on_format": {
@@ -13,7 +13,7 @@
 		"TSX": {
 			"formatter": {
 				"language_server": {
-					"name": "biome"
+					"name": "dprint"
 				}
 			},
 			"code_actions_on_format": {
@@ -23,14 +23,14 @@
 		"JSON": {
 			"formatter": {
 				"language_server": {
-					"name": "biome"
+					"name": "dprint"
 				}
 			}
 		},
 		"JSONC": {
 			"formatter": {
 				"language_server": {
-					"name": "biome"
+					"name": "dprint"
 				}
 			}
 		}

--- a/biome.json
+++ b/biome.json
@@ -24,20 +24,6 @@
 			"!**/worker-configuration.d.ts"
 		]
 	},
-	"javascript": {
-		"formatter": {
-			"semicolons": "asNeeded",
-			"trailingCommas": "all"
-		}
-	},
-	"formatter": {
-		"enabled": true,
-		"formatWithErrors": false,
-		"indentStyle": "tab",
-		"indentWidth": 2,
-		"lineWidth": 81,
-		"includes": ["**", "!**/*.gen.ts", "!**/*.cache.json"]
-	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,8 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
         "@changesets/cli": "3.0.0",
+        "@dprint/biome": "0.13.6",
+        "@dprint/markdown": "0.22.1",
         "@eslint/eslintrc": "3.3.6",
         "@eslint/js": "10.0.1",
         "@types/eslint": "9.6.1",
@@ -14,6 +16,7 @@
         "@typescript-eslint/parser": "8.67.0",
         "c8": "12.0.0",
         "cross-env": "10.1.0",
+        "dprint": "0.55.2",
         "eslint": "10.8.1",
         "eslint-plugin-import-x": "4.17.1",
         "eslint-plugin-simple-import-sort": "14.0.0",
@@ -108,6 +111,7 @@
     "@biomejs/biome",
     "rolldown",
     "unrs-resolver",
+    "dprint",
     "bun",
     "workerd",
   ],
@@ -222,6 +226,40 @@
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@dprint/android-arm64": ["@dprint/android-arm64@0.55.2", "", { "os": "android", "cpu": "arm64" }, "sha512-cywqM0E2h8lCA/b5BMFcuascaGuekm2lnyKb5hRH9juKbsqKeR8A7qf2p3nVWRQ8cM7djOnQwhy8ecQ3qd6j9A=="],
+
+    "@dprint/android-x64": ["@dprint/android-x64@0.55.2", "", { "os": "android", "cpu": "x64" }, "sha512-BvcqquD94dSYQP2FzBuojU/8vITpwz80uAkub2xCCx5g7zYdUZ98tK+N3GKfRS5AUJ1LpRPJgbO09rRLEo8leA=="],
+
+    "@dprint/biome": ["@dprint/biome@0.13.6", "", {}, "sha512-fRhV86WPXwxLOPDmhMNWGf4fdkVv+fFNrXLV6IHfXR6mynu/ZbDr3htlijpkblS6KHbRCSXu/riA142s1/JKWw=="],
+
+    "@dprint/darwin-arm64": ["@dprint/darwin-arm64@0.55.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HjzasuPaC0EBHxEpS3Px/OPcxqZYln37xuAyYE0GFAhDuaotZEUpM8VE05Tzo4E32y7LKgLPT8CZVtEG5Ck7mQ=="],
+
+    "@dprint/darwin-x64": ["@dprint/darwin-x64@0.55.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-7XSF9XERvimg3XakXNlJRpJM9an5HKibWWShwCJr7Dz1Xp7P3pomjx9AtYV5EeD49GXu9FKdFfDiTC4BJtAVjA=="],
+
+    "@dprint/linux-arm64-glibc": ["@dprint/linux-arm64-glibc@0.55.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-2h5oe4tHGXJOTLU5BxVJLGPP1qQQxxECdjUaRkLxGn2rZIEf/7HwoJ+TjwMUaIVg4QxAFxfiMJJ3MRZjumJpsg=="],
+
+    "@dprint/linux-arm64-musl": ["@dprint/linux-arm64-musl@0.55.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z1X9mNLHWoSI7CHz888H2w27IV2UQ5lL/YbTwgguJM9ApLgvkMer5qr4pLlXF6vEY3+Rm0445eo3uojbjE7PTw=="],
+
+    "@dprint/linux-loong64-glibc": ["@dprint/linux-loong64-glibc@0.55.2", "", { "os": "linux", "cpu": "none" }, "sha512-qxk4Cg/SjO14DALoG1MFZL+n6pEvCyd7VDHg1cQIpp82mZ+wtRaWkJqSaItWj12x8jihA32wAoQ/8OHz+5FFsQ=="],
+
+    "@dprint/linux-loong64-musl": ["@dprint/linux-loong64-musl@0.55.2", "", { "os": "linux", "cpu": "none" }, "sha512-Mr+kRdZnxhUHBmhhADkYOo1g81PYvbh7eBo+lpMStgIvL/5Z93mGAcp/1NFcpeN02pilaI1N59awV08ApJ19cA=="],
+
+    "@dprint/linux-ppc64-glibc": ["@dprint/linux-ppc64-glibc@0.55.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-C8XEL3f3yg+MWZD4qlot+ibJ0GDPvCT5jq9ErwPdKteyIPpe6IPSqiEApYSQ194Q7audL8rgS0WdJsW4HNVhmw=="],
+
+    "@dprint/linux-ppc64-musl": ["@dprint/linux-ppc64-musl@0.55.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tSGe4bTmL5/EhNH38baCKWBGxOXVB0M5Loxnpls7wsQjuLpzWnzDCw4wiO3C7PrKLbAe4sJUWhbgdDXa3TJ2eQ=="],
+
+    "@dprint/linux-riscv64-glibc": ["@dprint/linux-riscv64-glibc@0.55.2", "", { "os": "linux", "cpu": "none" }, "sha512-gSaoq9e3vGTfYm5jcEd86YysFsp8OJF/CGZgBzNNu3NSjLEs8VVgTObDxQI+U7ex2mA17lbpWyr3diejaaK+bg=="],
+
+    "@dprint/linux-x64-glibc": ["@dprint/linux-x64-glibc@0.55.2", "", { "os": "linux", "cpu": "x64" }, "sha512-GBLWjuqTT5OGbqh2gQENQihhfRn/AjdDu2SVwjmbZcOFR80HMppIfFrIIolBB3FLyrZk+M8rMk8EAo0tQ3PAXw=="],
+
+    "@dprint/linux-x64-musl": ["@dprint/linux-x64-musl@0.55.2", "", { "os": "linux", "cpu": "x64" }, "sha512-GZEUpmtxCOiauRtqOqT/erAjy2ws8dOxx7oQJFf9g5bypisuapwymvr7fUVVb8nqccFqjx7E5kN4IxKDlzntHA=="],
+
+    "@dprint/markdown": ["@dprint/markdown@0.22.1", "", {}, "sha512-L5BYR66HNxs5vmGGYze/SP9wrIJnHIhbZGCbdP2N+o5gbukhau3ulFbaG/rB7u9H51LXGePue1sFXVgS5IiU2A=="],
+
+    "@dprint/win32-arm64": ["@dprint/win32-arm64@0.55.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-dxDdxU4a6wQ4K0omdAxW7o0mUdOI03z0/Ah3N6O9Ja7wAMQI5sbfzq7DOJ739UVXtHSB4zBTtYuk1MrBOIyVQQ=="],
+
+    "@dprint/win32-x64": ["@dprint/win32-x64@0.55.2", "", { "os": "win32", "cpu": "x64" }, "sha512-UTiDSShHbrkx+z719/MffgwGYD8PaypdVmG4vVJVjmF5Hoin6EfugHhSoBf8+G6U9rF+uDIIl0idZq+6Bifzwg=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
@@ -876,6 +914,8 @@
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dprint": ["dprint@0.55.2", "", { "optionalDependencies": { "@dprint/android-arm64": "0.55.2", "@dprint/android-x64": "0.55.2", "@dprint/darwin-arm64": "0.55.2", "@dprint/darwin-x64": "0.55.2", "@dprint/linux-arm64-glibc": "0.55.2", "@dprint/linux-arm64-musl": "0.55.2", "@dprint/linux-loong64-glibc": "0.55.2", "@dprint/linux-loong64-musl": "0.55.2", "@dprint/linux-ppc64-glibc": "0.55.2", "@dprint/linux-ppc64-musl": "0.55.2", "@dprint/linux-riscv64-glibc": "0.55.2", "@dprint/linux-x64-glibc": "0.55.2", "@dprint/linux-x64-musl": "0.55.2", "@dprint/win32-arm64": "0.55.2", "@dprint/win32-x64": "0.55.2" }, "bin": { "dprint": "bin.cjs" } }, "sha512-1d4D4SB9KiD2qFnBWbl3aoYjLvPVpZoth28yxTT00xJv2yXugdz0Xoyv7sGG0w0hzE6hQZMgd6B333GnySDpGQ=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
 

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://dprint.dev/schemas/v0.json",
+	"lineWidth": 81,
+	"useTabs": true,
+	"indentWidth": 2,
+	"includes": [
+		"**/*.{ts,tsx,cts,mts,js,jsx,cjs,mjs,json,jsonc,css,graphql}",
+		"**/CHANGELOG.md"
+	],
+	"excludes": [
+		"**/metafile-*",
+		"**/*.cache.json",
+		"**/*.gen.ts",
+		"**/*.gen.tsx",
+		"**/*.tsdoc.json",
+		"**/.turbo/**",
+		"**/.varmint/**",
+		"**/.wrangler/**",
+		"**/app/**",
+		"**/bin/**",
+		"**/coverage/**",
+		"**/dist/**",
+		"**/drizzle/meta/**",
+		"**/heap.json",
+		"**/node_modules/**",
+		"**/projects/**",
+		"**/worker-configuration.d.ts"
+	],
+	"biome": {
+		"css.enabled": true,
+		"graphql.enabled": true,
+		"semicolons": "asNeeded",
+		"trailingCommas": "all"
+	},
+	"markdown": {
+		"associations": ["**/CHANGELOG.md"]
+	},
+	"plugins": [
+		"./node_modules/@dprint/biome/plugin.wasm",
+		"./node_modules/@dprint/markdown/plugin.wasm"
+	]
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
 	"type": "module",
 	"description": "",
 	"main": "index.js",
-	"workspaces": [
-		"packages/*",
-		"recoverage.cloud"
-	],
+	"workspaces": ["packages/*", "recoverage.cloud"],
 	"scripts": {
 		"gen": "turbo run gen",
 		"lint": "turbo run lint",
@@ -16,10 +13,10 @@
 		"lint:eslint": "turbo run lint:eslint",
 		"lint:types": "turbo run lint:types",
 		"watch:types": "turbo run watch:types --concurrency=30",
-		"lint:fix:biome": "biome check --write *",
+		"lint:fix:biome": "biome lint --write *",
 		"lint:fix:eslint": "NODE_OPTIONS=--require=./scripts/eslint-typescript.cjs eslint --fix .",
-		"fmt": "biome format .",
-		"fmt:fix": "biome format --write .",
+		"fmt": "dprint check",
+		"fmt:fix": "dprint fmt",
 		"build": "turbo run build",
 		"bench": "cd lib && vitest bench",
 		"test": "cross-env CI=true turbo run test:once --concurrency=2",
@@ -36,6 +33,8 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.5.8",
 		"@changesets/cli": "3.0.0",
+		"@dprint/biome": "0.13.6",
+		"@dprint/markdown": "0.22.1",
 		"@eslint/eslintrc": "3.3.6",
 		"@eslint/js": "10.0.1",
 		"@types/eslint": "9.6.1",
@@ -43,6 +42,7 @@
 		"@typescript-eslint/parser": "8.67.0",
 		"c8": "12.0.0",
 		"cross-env": "10.1.0",
+		"dprint": "0.55.2",
 		"eslint": "10.8.1",
 		"eslint-plugin-import-x": "4.17.1",
 		"eslint-plugin-simple-import-sort": "14.0.0",
@@ -58,6 +58,7 @@
 	"trustedDependencies": [
 		"@biomejs/biome",
 		"bun",
+		"dprint",
 		"esbuild",
 		"rolldown",
 		"sharp",

--- a/packages/recoverage/__tests__/sample-package-01/package.json
+++ b/packages/recoverage/__tests__/sample-package-01/package.json
@@ -1,7 +1,5 @@
 {
-	"workspaces": [
-		"packages/*"
-	],
+	"workspaces": ["packages/*"],
 	"type": "module",
 	"devDependencies": {
 		"@vitest/coverage-v8": "4.1.0",

--- a/packages/recoverage/__tests__/sample-package-02/package.json
+++ b/packages/recoverage/__tests__/sample-package-02/package.json
@@ -1,7 +1,5 @@
 {
-	"workspaces": [
-		"packages/*"
-	],
+	"workspaces": ["packages/*"],
 	"type": "module",
 	"devDependencies": {
 		"@vitest/coverage-v8": "4.1.0",

--- a/packages/recoverage/package.json
+++ b/packages/recoverage/package.json
@@ -15,11 +15,7 @@
 		"directory": "packages/recoverage"
 	},
 	"type": "module",
-	"files": [
-		"bin",
-		"dist",
-		"src"
-	],
+	"files": ["bin", "dist", "src"],
 	"main": "dist/recoverage.js",
 	"types": "dist/recoverage.d.ts",
 	"exports": {
@@ -39,14 +35,14 @@
 	"scripts": {
 		"dev": "bun --bun tsdown --watch",
 		"build": "bun --bun tsdown && rm -f dist/*.x.d.ts",
-		"lint:biome": "biome check -- .",
+		"lint:biome": "biome lint -- .",
 		"lint:eslint": "NODE_OPTIONS=--require=../../scripts/eslint-typescript.cjs eslint -- .",
 		"lint:types": "tsc --noEmit",
 		"watch:types": "tsc --watch --noEmit",
 		"lint": "concurrently \"bun:lint:*\"",
 		"test": "vitest",
 		"test:once": "vitest run",
-		"postversion": "biome format --write package.json"
+		"postversion": "dprint fmt package.json"
 	},
 	"dependencies": {
 		"@t3-oss/env-core": "0.13.11",

--- a/recoverage.cloud/package.json
+++ b/recoverage.cloud/package.json
@@ -16,7 +16,7 @@
 		"test:once": "vitest run",
 		"db:gen": "drizzle-kit generate",
 		"db:up": "wrangler d1 migrations apply recoverage-data",
-		"lint:biome": "biome check -- .",
+		"lint:biome": "biome lint -- .",
 		"lint:eslint": "NODE_OPTIONS=--require=../scripts/eslint-typescript.cjs eslint -- .",
 		"lint:types": "concurrently \"bun:lint:types:*\"",
 		"lint:types:main": "tsc --noEmit",

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
 bun changeset version
-bun fmt:fix


### PR DESCRIPTION
## Summary

- pin dprint 0.55.2 plus the npm-distributed Biome and Markdown plugins
- move formatting scripts and editor settings to dprint while keeping the Biome CLI focused on linting
- enable the Changesets v3 `format: dprint` integration and remove the extra post-version formatting pass
- preserve the existing Biome 2.5.8 formatting engine and settings through `@dprint/biome` 0.13.6

## Notes

- dprint officially supports project-local npm installation: https://dprint.dev/install/
- the official Biome adapter runs Biome inside dprint: https://dprint.dev/plugins/biome/
- adapter 0.13.6 embeds the same Biome 2.5.8 release already pinned here: https://github.com/dprint/dprint-plugin-biome/blob/0.13.6/Cargo.toml#L28-L38
- the Markdown plugin is scoped to changelogs because Changesets formats generated `CHANGELOG.md` files as well as package manifests
- this follows the npm-pinned plugin and local editor-binary patterns used in Lasertag

## Verification

- `bun install --frozen-lockfile`
- `bun fmt`
- `bun lint`
- `bun lint:deps`
- `bun run build`
- `bun test:coverage:increased`
- `bun test:semver`
- affected unit and cloud tests
- disposable `changeset version` run with a real patch changeset, verifying dprint formats both the manifest and changelog
